### PR TITLE
Fix error in v6 due to brackets returned in GetBuildVersion

### DIFF
--- a/SchematicPositionsToLayout.py
+++ b/SchematicPositionsToLayout.py
@@ -8,7 +8,7 @@ import shlex
 
 if hasattr(pcbnew, 'GetBuildVersion'):
     BUILD_VERSION = pcbnew.GetBuildVersion()
-    MAJOR, MINOR = tuple(map(int, BUILD_VERSION.split('~')[0].split('.')[:2]))
+    MAJOR, MINOR = tuple(map(int, BUILD_VERSION.strip('()').split('~')[0].split('.')[:2]))
     if MAJOR >= 6 or MAJOR == 5 and MINOR == 99:
         ENABLE_KICAD_V6_API=True
 else:


### PR DESCRIPTION
For some reason `GetBuildVersion` started returning a value containing brackets like `(6.0.0)`, so they must be stripped to avoid an exception.

This plugin is awesome!